### PR TITLE
Initial FastAPI backend setup with docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+node_modules
+frontend_node_modules
+.env
+.git
+.gitignore

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+MONGO_USER=admin
+MONGO_PASSWORD=pass
+MONGO_DB_NAME=ia_db
+PICTURE_VOLUME=ia_pictures
+PICTURES_REPOSITORY=/pictures
+REDIS_URL=redis://ia_redis:6379/0
+FLOWER_USER=admin
+FLOWER_PASSWORD=admin
+FLOWER_HOST=ia_flower
+FLOWER_PORT=5555
+MONGO_URI=mongodb://ia_mongo:27017/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+!*.example
+node_modules/
+frontend_node_modules/
+backend_logs/
+venv/
+.idea/
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,6 @@
+import os
+from celery import Celery
+
+celery_app = Celery(__name__)
+celery_app.conf.broker_url = os.getenv("REDIS_URL", "redis://ia_redis:6379/0")
+celery_app.conf.result_backend = os.getenv("REDIS_URL", "redis://ia_redis:6379/0")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI
+import os
+import socket
+import subprocess
+from pymongo import MongoClient
+from redis import Redis
+from celery import Celery
+from .celery_app import celery_app
+
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    status = {}
+    # Mongo
+    try:
+        uri = os.getenv("MONGO_URI", "mongodb://ia_mongo:27017/")
+        client = MongoClient(uri, serverSelectionTimeoutMS=2000)
+        client.admin.command('ping')
+        status["mongo"] = "ok"
+    except Exception:
+        status["mongo"] = "error"
+    # Redis
+    try:
+        redis_url = os.getenv("REDIS_URL", "redis://ia_redis:6379/0")
+        r = Redis.from_url(redis_url)
+        r.ping()
+        status["redis"] = "ok"
+    except Exception:
+        status["redis"] = "error"
+    # Celery
+    try:
+        celery_app.control.ping(timeout=1)
+        status["celery"] = "ok"
+    except Exception:
+        status["celery"] = "error"
+    # Flower
+    try:
+        flower_host = os.getenv("FLOWER_HOST", "ia_flower")
+        flower_port = int(os.getenv("FLOWER_PORT", 5555))
+        with socket.create_connection((flower_host, flower_port), timeout=2):
+            status["flower"] = "ok"
+    except Exception:
+        status["flower"] = "error"
+    # Spark
+    try:
+        subprocess.run(["spark-submit", "--version"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        status["spark"] = "ok"
+    except Exception:
+        status["spark"] = "error"
+    # Hadoop
+    try:
+        subprocess.run(["hadoop", "version"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        status["hadoop"] = "ok"
+    except Exception:
+        status["hadoop"] = "error"
+    return status

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,5 @@
+from .celery_app import celery_app
+
+@celery_app.task
+def ping():
+    return "pong"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+celery
+redis
+pymongo
+pyspark
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,114 @@
+version: '3.8'
+services:
+  ia_frontend:
+    image: node:22-alpine
+    container_name: ia_frontend
+    working_dir: /app
+    env_file:
+      - ./.env
+    volumes:
+      - ./frontend:/app
+      - ia_frontend_node_modules:/app/node_modules
+    ports:
+      - "5173:5173"
+    command: >
+      sh -c "
+      npm install -g pnpm &&
+      pnpm install &&
+      pnpm run dev -- --host=0.0.0.0 --port=5173docker-compose down
+      "
+  ia_backend:
+    container_name: ia_backend
+    build:
+      context: ./backend
+    env_file:
+      - ./backend/.env
+      - ./.env
+    volumes:
+      - ./backend:/app
+      - ia_backend_logs:/app/logs
+      - ${PICTURE_VOLUME}:${PICTURES_REPOSITORY}
+    ports:
+      - "5001:5000"
+    command: >
+      sh -c "
+      pip install -r requirements.txt &&
+      uvicorn app.main:app --host 0.0.0.0 --port 5000 --reload
+      "
+
+  ia_worker:
+    container_name: ia_worker
+    build:
+      context: ./backend
+    env_file:
+      - ./backend/.env
+      - ./.env
+    volumes:
+      - ./backend:/app
+      - ${PICTURE_VOLUME}:${PICTURES_REPOSITORY}
+    command: celery -A app.celery_app.celery_app worker --loglevel=INFO
+
+  ia_redis:
+    container_name: ia_redis
+    image: redis:8-alpine
+    volumes:
+      - ia_redis_data:/data
+
+  ia_mongo:
+    container_name: ia_mongo
+    image: mongo:4
+    volumes:
+      - ia_mongo_data:/data/db
+      - ./mongo-init:/docker-entrypoint-initdb.d:ro
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: ${MONGO_DB_NAME}
+    ports:
+      - "27017:27017"
+
+  ia_flower:
+    image: python:3.11-slim
+    container_name: ia_flower
+    env_file:
+      - ./.env
+      - ./backend/.env
+    volumes:
+      - ./backend:/app
+    working_dir: /app
+    depends_on:
+      - ia_redis
+    ports:
+      - "5555:5555"
+    command: >
+      sh -c "
+        pip install --no-cache-dir -r requirements.txt flower &&
+        celery -A app.tasks flower \
+          --port=5555 \
+          --broker=${REDIS_URL} \
+          --url_prefix=/flower \
+          --basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}
+      "
+
+  ia_hadoop:
+    image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8
+    container_name: ia_hadoop
+    environment:
+      - CLUSTER_NAME=ia_hadoop
+    ports:
+      - "9870:9870"
+      - "9000:9000"
+
+  ia_spark:
+    image: bitnami/spark:latest
+    container_name: ia_spark
+    environment:
+      - SPARK_MODE=master
+    ports:
+      - "8080:8080"
+
+volumes:
+  ia_redis_data:
+  ia_mongo_data:
+  ia_backend_logs:
+  ia_frontend_node_modules:

--- a/frontend2/Dockerfile
+++ b/frontend2/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
+
+COPY . .
+RUN pnpm run build
+
+FROM node:22-alpine AS production
+WORKDIR /app
+RUN npm install -g serve
+COPY --from=builder /app/dist ./dist
+EXPOSE 3000
+CMD ["serve", "-s", "dist", "-l", "3000"]

--- a/mongo-init/init-collection.js
+++ b/mongo-init/init-collection.js
@@ -1,0 +1,4 @@
+print('Initializing MongoDB...');
+const dbName = process.env.MONGO_INITDB_DATABASE;
+db = db.getSiblingDB(dbName);
+db.createCollection('USERS');


### PR DESCRIPTION
## Summary
- add FastAPI backend skeleton with `/health` route
- provide Celery config and simple task
- dockerize backend and add frontend build Dockerfile
- configure docker compose with prefixed service names plus Hadoop and Spark
- add Mongo init script and environment examples
- include git and docker ignore files

## Testing
- `python -m py_compile backend/app/*.py`
- `python -m compileall backend`
- *(docker-compose unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688b7f32d130832588b2ec9c382eb9a3